### PR TITLE
Configure which language modes activate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ansi-cyan": {
@@ -70,7 +70,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -79,8 +79,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.0.1",
-                "array-slice": "^0.2.3"
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
             }
         },
         "arr-flatten": {
@@ -113,7 +113,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -170,9 +170,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -181,11 +181,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 }
             }
@@ -203,7 +203,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "block-stream": {
@@ -212,7 +212,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "brace-expansion": {
@@ -221,7 +221,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -231,9 +231,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
             }
         },
         "browser-stdout": {
@@ -272,9 +272,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -283,7 +283,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "supports-color": {
@@ -292,7 +292,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -321,9 +321,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "co": {
@@ -353,7 +353,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -386,7 +386,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "debug": {
@@ -404,7 +404,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "delayed-stream": {
@@ -431,10 +431,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -444,7 +444,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "end-of-stream": {
@@ -453,7 +453,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -480,13 +480,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "expand-brackets": {
@@ -495,7 +495,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -504,7 +504,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             }
         },
         "extend": {
@@ -519,7 +519,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "^1.1.0"
+                "kind-of": "1.1.0"
             }
         },
         "extglob": {
@@ -528,7 +528,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -563,7 +563,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "filename-regex": {
@@ -578,11 +578,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.0.0",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
             }
         },
         "first-chunk-stream": {
@@ -603,7 +603,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -618,9 +618,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.19"
             }
         },
         "from": {
@@ -641,10 +641,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "getpass": {
@@ -653,7 +653,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -662,12 +662,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -676,8 +676,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -686,7 +686,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -701,7 +701,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -712,8 +712,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -722,14 +722,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.2",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
             },
             "dependencies": {
                 "glob": {
@@ -738,11 +738,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -757,10 +757,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -775,8 +775,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -799,9 +799,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
             }
         },
         "gulp-filter": {
@@ -810,9 +810,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -821,8 +821,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -837,10 +837,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -855,8 +855,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -867,11 +867,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.87.0",
+                "through2": "2.0.3",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -892,12 +892,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -908,11 +908,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -933,8 +933,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -946,10 +946,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
             }
         },
         "gulp-untar": {
@@ -958,11 +958,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
+                "event-stream": "3.3.4",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -983,8 +983,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -996,13 +996,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^2.0.0",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "event-stream": "3.3.4",
+                "queue": "4.4.2",
+                "through2": "2.0.3",
+                "vinyl": "2.2.0",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.10.0",
+                "yazl": "2.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -1023,7 +1023,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.3"
                     }
                 },
                 "vinyl": {
@@ -1032,12 +1032,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1054,8 +1054,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has-ansi": {
@@ -1064,7 +1064,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -1085,9 +1085,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.2"
             }
         },
         "inflight": {
@@ -1096,8 +1096,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -1130,7 +1130,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -1151,7 +1151,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-number": {
@@ -1160,7 +1160,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1169,7 +1169,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1249,8 +1249,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -1278,7 +1278,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1317,7 +1317,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lodash.isequal": {
@@ -1344,7 +1344,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -1353,19 +1353,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1374,7 +1374,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "is-extglob": {
@@ -1389,7 +1389,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1398,7 +1398,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1415,7 +1415,7 @@
             "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.35.0"
+                "mime-db": "1.35.0"
             }
         },
         "minimatch": {
@@ -1424,7 +1424,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -1484,7 +1484,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
@@ -1501,10 +1501,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "node.extend": {
@@ -1513,7 +1513,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "^3.1.0"
+                "is": "3.2.1"
             }
         },
         "normalize-path": {
@@ -1522,7 +1522,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "oauth-sign": {
@@ -1543,8 +1543,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "once": {
@@ -1553,7 +1553,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "ordered-read-streams": {
@@ -1562,8 +1562,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "^1.0.1",
-                "readable-stream": "^2.0.1"
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.6"
             }
         },
         "parse-glob": {
@@ -1572,10 +1572,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1590,7 +1590,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -1619,7 +1619,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pend": {
@@ -1640,11 +1640,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             }
         },
         "preserve": {
@@ -1683,7 +1683,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "randomatic": {
@@ -1692,9 +1692,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -1717,13 +1717,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "regex-cache": {
@@ -1732,7 +1732,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -1765,26 +1765,26 @@
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.19",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "requires-port": {
@@ -1799,7 +1799,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "rimraf": {
@@ -1808,7 +1808,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             }
         },
         "safe-buffer": {
@@ -1841,8 +1841,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.0",
+                "source-map": "0.6.1"
             }
         },
         "split": {
@@ -1851,7 +1851,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "sprintf-js": {
@@ -1866,15 +1866,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stat-mode": {
@@ -1889,7 +1889,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-shift": {
@@ -1904,7 +1904,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "streamifier": {
@@ -1919,7 +1919,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -1928,7 +1928,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -1937,7 +1937,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-bom-stream": {
@@ -1946,8 +1946,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
             }
         },
         "supports-color": {
@@ -1962,9 +1962,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "through": {
@@ -1979,8 +1979,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "through2-filter": {
@@ -1989,8 +1989,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "to-absolute-glob": {
@@ -1999,7 +1999,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2008,7 +2008,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -2019,7 +2019,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
         },
         "tslib": {
@@ -2034,18 +2034,18 @@
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.27.2"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.16.0",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.12.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.8.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.3",
+                "tsutils": "2.28.0"
             }
         },
         "tsutils": {
@@ -2054,7 +2054,7 @@
             "integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.3"
             }
         },
         "tunnel-agent": {
@@ -2063,7 +2063,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -2085,8 +2085,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
             }
         },
         "url-parse": {
@@ -2095,8 +2095,8 @@
             "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
             "dev": true,
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.0.0",
+                "requires-port": "1.0.0"
             }
         },
         "util-deprecate": {
@@ -2123,9 +2123,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -2134,8 +2134,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
             }
         },
         "vinyl-fs": {
@@ -2144,23 +2144,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
-                "graceful-fs": "^4.0.0",
+                "duplexify": "3.6.0",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
-                "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
-                "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.6",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -2181,8 +2181,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2194,8 +2194,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
             }
         },
         "vscode": {
@@ -2204,20 +2204,20 @@
             "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.0",
-                "gulp-symdest": "^1.1.0",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.0",
-                "mocha": "^4.0.1",
-                "request": "^2.83.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.1.9",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.0",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.7",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.1.0",
+                "request": "2.87.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.6",
+                "url-parse": "1.4.1",
+                "vinyl-source-stream": "1.1.2"
             }
         },
         "wrappy": {
@@ -2238,8 +2238,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.1.0"
             }
         },
         "yazl": {
@@ -2248,7 +2248,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
             "type": "object",
             "title": "Markdown Checkbox",
             "properties": {
+                "markdown-checkbox.languages": {
+                    "type": "array",
+                    "default": [ "markdown" ],
+                    "description": "The language modes that this package will activate within"
+                },
                 "markdown-checkbox.withBulletPoint": {
                     "type": "boolean",
                     "default": true,

--- a/src/commands/createCheckbox.ts
+++ b/src/commands/createCheckbox.ts
@@ -1,20 +1,15 @@
 import * as vscode from 'vscode';
 import { createCheckbox } from '../createCheckbox';
-import { getEditor } from '../helpers';
+import * as helpers from '../helpers';
 
 export const createCheckboxCommand = vscode.commands.registerCommand('markdown-checkbox.createCheckbox', () => {
-    const editor = getEditor();
-
-    if (!editor) {
+    if (! helpers.shouldActivate()) {
         return;
     }
 
-    const doc = editor.document;
-    if (doc.languageId === 'markdown') {
-        try {
-            createCheckbox(editor);
-        } catch (error) {
-            console.log(error);
-        }
+    try {
+        createCheckbox(helpers.getEditor());
+    } catch (error) {
+        console.log(error);
     }
 });

--- a/src/commands/markCheckbox.ts
+++ b/src/commands/markCheckbox.ts
@@ -3,19 +3,13 @@ import * as helpers from '../helpers';
 import { toggleCheckbox } from '../toggleCheckbox';
 
 export const markCheckboxCommand = vscode.commands.registerCommand('markdown-checkbox.markCheckbox', () => {
-    const editor = helpers.getEditor();
-
-    if (!editor) {
+    if (! helpers.shouldActivate()) {
         return;
     }
 
-    const doc = editor.document;
-
-    if (doc.languageId === 'markdown') {
-        try {
-            toggleCheckbox();
-        } catch (error) {
-            console.log(error);
-        }
+    try {
+        toggleCheckbox();
+    } catch (error) {
+        console.log(error);
     }
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { CheckboxStatus, CheckboxStatusController } from './checkboxStatus';
 import { createCheckboxCommand } from './commands/createCheckbox';
 import { markCheckboxCommand } from './commands/markCheckbox';
-import { showQuickPickCommand } from './commands/quickpick';
+import { showQuickPickCommand } from './commands/quickPick';
 
 export const activate = (context: vscode.ExtensionContext) => {
     // item in the status bar to show checkbox information

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,3 +67,31 @@ export const getPlainLineText = (text: string) => {
 /** Get the value of a workspace config property */
 export const getConfig = (config: string): any =>
     vscode.workspace.getConfiguration('markdown-checkbox').get(config);
+
+/** Determine whether a given language ID is valid for our configuration */
+export const isActivationLanguageId = (languageId: string): boolean => {
+    const config: string | string[] =
+        vscode.workspace.getConfiguration('markdown-checkbox').get<string | string[]>('languages');
+
+    if (! config) {
+        return languageId === 'markdown';
+    }
+
+    if (typeof config === 'string') {
+        return config === languageId;
+    }
+
+    return config.indexOf(languageId) !== -1;
+};
+
+/** Follow all the rules to determine if we should activate a command */
+export const shouldActivate = (): boolean => {
+    const editor = getEditor();
+
+    if (! editor) {
+        return false;
+    }
+
+    return isActivationLanguageId(editor.document.languageId);
+};
+


### PR DESCRIPTION
Hi Pkief, thank you and any other contributors for this awesome extension! I wanted to use this extension in my org-mode files (it works perfectly!) except that the language mode was restricted to "markdown". This PR adds a configuration option which is a list of language modes to activate the commands on (quick pick remains agnostic).

There is also a typo that showed up in my linter as well as a package-lock.json update. I don't know whether these 2 commits are appropriate, and they aren't necessary to the core of my contribution here.

Thanks!