### PR TITLE
Make date format configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,15 @@
             "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
             "dev": true
         },
+        "@types/moment": {
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+            "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+            "dev": true,
+            "requires": {
+                "moment": "*"
+            }
+        },
         "@types/node": {
             "version": "11.13.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
@@ -705,9 +714,9 @@
             "dev": true
         },
         "cacache": {
-            "version": "12.0.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-            "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+            "version": "12.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+            "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.5.5",
@@ -1532,9 +1541,9 @@
             "dev": true
         },
         "figgy-pudding": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-            "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+            "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
             "dev": true
         },
         "fill-range": {
@@ -2823,9 +2832,9 @@
             },
             "dependencies": {
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -3039,9 +3048,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mississippi": {
@@ -3084,12 +3093,12 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "mocha": {
@@ -3142,6 +3151,21 @@
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
                     "dev": true
                 },
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
                 "supports-color": {
                     "version": "4.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -3152,6 +3176,11 @@
                     }
                 }
             }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "move-concurrently": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -147,12 +147,18 @@
                     ],
                     "default": "X",
                     "description": "Checkmark of the checkbox."
+                },
+                "markdown-checkbox.dateFormat": {
+                    "type": "string",
+                    "default": "YYYY-MM-DD",
+                    "description": "Format date"
                 }
             }
         }
     },
     "devDependencies": {
         "@types/mocha": "^5.2.6",
+        "@types/moment": "^2.13.0",
         "@types/node": "^11.13.7",
         "clean-webpack-plugin": "^2.0.1",
         "ts-loader": "^5.4.3",
@@ -161,5 +167,8 @@
         "vscode": "^1.1.33",
         "webpack": "^4.30.0",
         "webpack-cli": "^3.3.1"
+    },
+    "dependencies": {
+        "moment": "^2.24.0"
     }
 }

--- a/src/toggleCheckbox.ts
+++ b/src/toggleCheckbox.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Position, Range, TextEditorEdit } from 'vscode';
 import * as helpers from './helpers';
+const moment = require('moment');
 
 /** Mark a checkbox as checked or unchecked */
 export const toggleCheckbox = async () => {

--- a/src/toggleCheckbox.ts
+++ b/src/toggleCheckbox.ts
@@ -69,10 +69,12 @@ const markField = (checkboxPosition: Position, replacement: string): Thenable<bo
         const foundTrailingWhitespace = lineText.substr(checkboxPosition.character + 4, lineText.length).match(/[\s\n\r]*$/);
         const whitespace = foundTrailingWhitespace ? foundTrailingWhitespace.join('') : '';
 
+        const dateFormat = helpers.getConfig<string>('dateFormat');
+
         if (!lhc.checked && textWithoutCheckbox.length > 0) {
             let newText = (strikeThroughWhenChecked ? '~~' : '') + (italicWhenChecked ? '*' : '') + textWithoutCheckbox + (italicWhenChecked ? '*' : '') + (strikeThroughWhenChecked ? '~~' : '');
             // add the date string
-            newText = newText + (dateWhenChecked ? ' [' + helpers.getDateString(new Date()) + ']' : '') + whitespace;
+            newText = newText + (dateWhenChecked ? ' [' + moment(new Date()).format(dateFormat) + ']' : '') + whitespace;
 
             editBuilder.replace(new Range(
                 new Position(checkboxPosition.line, checkboxPosition.character + 4),
@@ -82,7 +84,9 @@ const markField = (checkboxPosition: Position, replacement: string): Thenable<bo
         else if (lhc.checked) {
             let newText = textWithoutCheckbox.replace(/~~/g, '').replace(/\*/g, '');
             // remove the date string
-            newText = newText.replace(/\s+\[\d{4}[\-]\d{2}[\-]\d{2}\]\s*/, '') + whitespace;
+            if (dateWhenChecked) {
+                newText = newText.replace(/\s+\[[\s\S]+\]$/, '') + whitespace;
+            }
 
             editBuilder.replace(new Range(
                 new Position(checkboxPosition.line, checkboxPosition.character + 4),


### PR DESCRIPTION
This pull request makes the date format configurable through the settings.json:

```json
"markdown-checkbox.dateFormat": "YYYY-MM-DD"
```

It makes use of the JavaScript library [moment.js](https://momentjs.com/) which means that you can find the date format patterns on its documentation.