### PR TITLE
Add support for creating checkboxes on selected lines

### DIFF
--- a/src/createCheckbox.ts
+++ b/src/createCheckbox.ts
@@ -1,13 +1,19 @@
-import { Position, TextEditor, TextEditorEdit } from 'vscode';
+import { Position, TextEditor, TextEditorEdit, TextLine } from 'vscode';
 import * as helpers from './helpers';
 
-/** Create a new checkbox at the current cursor position */
-export const createCheckbox = (editor: TextEditor): any => {
+/** Create a new checkbox at selected lines or the current cursor position */
+export const createCheckbox = async (editor: TextEditor) => {
+    const selection = editor.selection;
+
+    for (let r = selection.start.line; r <= selection.end.line; r++) {
+        const line = editor.document.lineAt(r);
+        await createCheckboxOfLine(editor, line);
+    }
+};
+
+const createCheckboxOfLine = (editor: TextEditor, line: TextLine): Thenable<boolean> => {
     const withBulletPoint = helpers.getConfig<boolean>('withBulletPoint');
     const typeOfBulletPoint = helpers.getConfig<string>('typeOfBulletPoint');
-    const cursorPosition = helpers.getCursorPosition();
-
-    const line = editor.document.lineAt(cursorPosition.line);
     const hasBullet = helpers.lineHasBulletPointAlready(line);
 
     if (!helpers.getCheckboxOfLine(line)) {
@@ -17,7 +23,7 @@ export const createCheckbox = (editor: TextEditor): any => {
                 hasBullet.pos
             ), (withBulletPoint && !hasBullet.bullet ? typeOfBulletPoint + ' ' : '') + '[ ] ');
         });
+    } else {
+        return Promise.resolve(undefined);
     }
-
-    return undefined;
 };

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { createCheckbox } from '../../../createCheckbox';
-import { getEditor } from '../../../helpers';
+import { getEditor, getConfig } from '../../../helpers';
 import { useDefaultSettings } from '..';
 
 describe('create checkboxes', () => {
@@ -24,9 +24,13 @@ describe('create checkboxes', () => {
         const newSelection = new vscode.Selection(newCursorPosition, newCursorPosition);
         editor.selection = newSelection;
 
-        const result = await createCheckbox(editor);
+        await createCheckbox(editor);
 
-        assert.equal(result, true);
+        const content = editor.document.getText();
+        const typeOfBulletPoint = getConfig<string>('typeOfBulletPoint');
+        const expectedResult = `${typeOfBulletPoint} [ ] this is a text`;
+
+        assert.equal(content, expectedResult);
     });
 
     it('should be created without new bullet point', async () => {
@@ -44,8 +48,11 @@ describe('create checkboxes', () => {
         const newSelection = new vscode.Selection(newCursorPosition, newCursorPosition);
         editor.selection = newSelection;
 
-        const result = await createCheckbox(editor);
+        await createCheckbox(editor);
 
-        assert.equal(result, true);
+        const content = editor.document.getText();
+        const expectedResult = `- [ ] this is a text`;
+
+        assert.equal(content, expectedResult);
     });
 });

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -55,4 +55,28 @@ describe('create checkboxes', () => {
 
         assert.equal(content, expectedResult);
     });
+
+    it('should be created with new bullet points', async () => {
+        // create new document
+        const newDocument = await vscode.workspace.openTextDocument({
+            content: 'this is a text\nthis is a second text\n- this is a third text',
+            language: 'markdown'
+        });
+        await vscode.window.showTextDocument(newDocument);
+
+        // create a selection over the text
+        const editor = getEditor();
+        const startPosition = new vscode.Position(0, 0);
+        const endPosition = new vscode.Position(2, 0);
+        const newSelection = new vscode.Selection(startPosition, endPosition);
+        editor.selection = newSelection;
+
+        await createCheckbox(editor);
+
+        const content = editor.document.getText();
+        const typeOfBulletPoint = getConfig<string>('typeOfBulletPoint');
+        const expectedResult = `${typeOfBulletPoint} [ ] this is a text\n${typeOfBulletPoint} [ ] this is a second text\n- [ ] this is a third text`
+
+        assert.equal(content, expectedResult);
+    });
 });


### PR DESCRIPTION
Hi. Thank you for maintaining this extension.

I'm often tempted to apply `Create checkbox` command to selected lines.  But `Create checkbox` command can only apply to a cursor line even if lines selected.

So I added support for it.  (I refered to the implementation of `Mark checkbox` command.)
