### PR TITLE
Allow users to define the date template

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ If dates are enabled, they can be formatted with the following user setting:
 
 It makes use of the JavaScript library [moment.js](https://momentjs.com/docs/#/parsing/string-format/) which means that the date format patterns can be found there.
 
+In addition the syntax around in which the date is placed can be defined via template. `{date}` will be replaced by the actual date value:
+
+```json
+"markdown-checkbox.dateTemplate": "({date})"
+```
+
+Preview:
+
+- [x] ~~_sample with date_~~ (2017-11-23)
+
 ### Specify language IDs
 
 Besides markdown, this extension can also be used for other languages in VS Code. The language IDs can be specified in the user settings like this:

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
         "markdown-checkbox.dateTemplate": {
           "type": "string",
           "default": "[{date}]",
-          "markdownDescription": "The date template: `${date}` is replaced by the actual date."
+          "markdownDescription": "The date template `{date}` is replaced by the actual date."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
           "type": "string",
           "default": "YYYY-MM-DD",
           "description": "Format date"
+        },
+        "markdown-checkbox.dateTemplate": {
+          "type": "string",
+          "default": "[{date}]",
+          "markdownDescription": "The date template: `${date}` is replaced by the actual date."
         }
       }
     }

--- a/src/toggleCheckbox.ts
+++ b/src/toggleCheckbox.ts
@@ -108,9 +108,11 @@ const markField = (
         newText = `~~${newText}~~`;
       }
       if (dateWhenChecked) {
-        newText = `${newText} [${moment(new Date()).format(
-          dateFormat
-        )}]${whitespace}`;
+        const date = moment(new Date()).format(dateFormat);
+        const decoratedDate = helpers
+          .getConfig<string>('dateTemplate')
+          .replace('{date}', date);
+        newText = `${newText} ${decoratedDate}${whitespace}`;
       }
 
       editBuilder.replace(


### PR DESCRIPTION
This is a suggestion to allow defining a date template to circumvent the "No link definition found" warning describe by issue [46](https://github.com/PKief/vscode-markdown-checkbox/issues/46).

Here's a quick video with the change in action:
https://user-images.githubusercontent.com/64930576/229313452-6c14316d-6ca5-417f-88b0-0cf389dfda0f.mov
