### PR TITLE
Insert date while creating a checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
           "type": "string",
           "default": "[{date}]",
           "markdownDescription": "The date template `{date}` is replaced by the actual date."
+        },
+        "markdown-checkbox.dateWhenCreated": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert the current date along with the created checkbox."
         }
       }
     }

--- a/src/createCheckbox.ts
+++ b/src/createCheckbox.ts
@@ -18,9 +18,11 @@ const createCheckboxOfLine = (
   const withBulletPoint = helpers.getConfig<boolean>('withBulletPoint');
   const typeOfBulletPoint = helpers.getConfig<string>('typeOfBulletPoint');
   const hasBullet = helpers.lineHasBulletPointAlready(line);
+  const dateWhenCreated = helpers.getConfig<boolean>('dateWhenCreated');
 
+  const dateNow = helpers.getDateString(new Date());
   const checkboxOfLine = helpers.getCheckboxOfLine(line);
-  const checkboxCharacters = '[ ] ';
+  const checkboxCharacters = dateWhenCreated ? `[ ] ${dateNow} ` : '[ ] ';
 
   return editor.edit((editBuilder: TextEditorEdit) => {
     if (!checkboxOfLine) {

--- a/src/createCheckbox.ts
+++ b/src/createCheckbox.ts
@@ -22,7 +22,11 @@ const createCheckboxOfLine = (
 
   const dateNow = helpers.getDateString(new Date());
   const checkboxOfLine = helpers.getCheckboxOfLine(line);
-  const checkboxCharacters = dateWhenCreated ? `[ ] ${dateNow} ` : '[ ] ';
+  const hasDate = helpers
+    .getPlainLineText(line.text)
+    .match(/^\d{4}-\d{2}-\d{2} /);
+  const checkboxCharacters =
+    dateWhenCreated && !hasDate ? `[ ] ${dateNow} ` : '[ ] ';
 
   return editor.edit((editBuilder: TextEditorEdit) => {
     if (!checkboxOfLine) {

--- a/src/createCheckbox.ts
+++ b/src/createCheckbox.ts
@@ -24,7 +24,7 @@ const createCheckboxOfLine = (
   const checkboxOfLine = helpers.getCheckboxOfLine(line);
   const hasDate = helpers
     .getPlainLineText(line.text)
-    .match(/^\d{4}-\d{2}-\d{2} /);
+    .match(/^(?:[+*-]\s)?\d{4}-\d{2}-\d{2} /);
   const checkboxCharacters =
     dateWhenCreated && !hasDate ? `[ ] ${dateNow} ` : '[ ] ';
 

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -174,7 +174,7 @@ describe('create checkboxes', () => {
     assert.strictEqual(content, expectedResult);
   });
 
-  it('should not insert creation date twice if exists', async () => {
+  it('should not insert another creation date', async () => {
     // create new document
     const newDocument = await vscode.workspace.openTextDocument({
       content: '9999-99-99 this is a text',
@@ -202,6 +202,37 @@ describe('create checkboxes', () => {
     const content = editor.document.getText();
     const typeOfBulletPoint = getConfig<string>('typeOfBulletPoint');
     const expectedResult = `${typeOfBulletPoint} [ ] 9999-99-99 this is a text`;
+
+    assert.strictEqual(content, expectedResult);
+  });
+
+  it('should not insert another creation date with existing bullet', async () => {
+    // create new document
+    const newDocument = await vscode.workspace.openTextDocument({
+      content: '- 9999-99-99 this is a text',
+      language: 'markdown',
+    });
+    await vscode.window.showTextDocument(newDocument);
+
+    // update config to insert creation date if configured
+    await vscode.workspace
+      .getConfiguration('markdown-checkbox')
+      .update('dateWhenCreated', true);
+
+    // set the cursor to the current line
+    const editor = getEditor();
+    const position = editor.selection.active;
+    const newCursorPosition = position.with(0, 0);
+    const newSelection = new vscode.Selection(
+      newCursorPosition,
+      newCursorPosition
+    );
+    editor.selection = newSelection;
+
+    await createCheckbox(editor);
+
+    const content = editor.document.getText();
+    const expectedResult = `- [ ] 9999-99-99 this is a text`;
 
     assert.strictEqual(content, expectedResult);
   });

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -141,13 +141,18 @@ describe('create checkboxes', () => {
     assert.strictEqual(content, expectedResult);
   });
 
-  it('should create checkbox with begin date', async () => {
+  it('should create checkbox with current date added', async () => {
     // create new document
     const newDocument = await vscode.workspace.openTextDocument({
       content: 'this is a text',
       language: 'markdown',
     });
     await vscode.window.showTextDocument(newDocument);
+
+    // update config to insert creation date if configured
+    await vscode.workspace
+      .getConfiguration('markdown-checkbox')
+      .update('dateWhenCreated', true);
 
     // set the cursor to the current line
     const editor = getEditor();

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -173,4 +173,36 @@ describe('create checkboxes', () => {
 
     assert.strictEqual(content, expectedResult);
   });
+
+  it('should not insert creation date twice if exists', async () => {
+    // create new document
+    const newDocument = await vscode.workspace.openTextDocument({
+      content: '9999-99-99 this is a text',
+      language: 'markdown',
+    });
+    await vscode.window.showTextDocument(newDocument);
+
+    // update config to insert creation date if configured
+    await vscode.workspace
+      .getConfiguration('markdown-checkbox')
+      .update('dateWhenCreated', true);
+
+    // set the cursor to the current line
+    const editor = getEditor();
+    const position = editor.selection.active;
+    const newCursorPosition = position.with(0, 0);
+    const newSelection = new vscode.Selection(
+      newCursorPosition,
+      newCursorPosition
+    );
+    editor.selection = newSelection;
+
+    await createCheckbox(editor);
+
+    const content = editor.document.getText();
+    const typeOfBulletPoint = getConfig<string>('typeOfBulletPoint');
+    const expectedResult = `${typeOfBulletPoint} [ ] 9999-99-99 this is a text`;
+
+    assert.strictEqual(content, expectedResult);
+  });
 });

--- a/src/test/spec/checkbox/createCheckbox.spec.ts
+++ b/src/test/spec/checkbox/createCheckbox.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { createCheckbox } from '../../../createCheckbox';
-import { getConfig, getEditor } from '../../../helpers';
+import { getConfig, getDateString, getEditor } from '../../../helpers';
 import { setSettingsToDefault } from '../defaultSettings';
 
 describe('create checkboxes', () => {
@@ -137,6 +137,34 @@ describe('create checkboxes', () => {
 
     const content = editor.document.getText();
     const expectedResult = `this is a text\nthis is a second text\n- this is a third text`;
+
+    assert.strictEqual(content, expectedResult);
+  });
+
+  it('should create checkbox with begin date', async () => {
+    // create new document
+    const newDocument = await vscode.workspace.openTextDocument({
+      content: 'this is a text',
+      language: 'markdown',
+    });
+    await vscode.window.showTextDocument(newDocument);
+
+    // set the cursor to the current line
+    const editor = getEditor();
+    const position = editor.selection.active;
+    const newCursorPosition = position.with(0, 0);
+    const newSelection = new vscode.Selection(
+      newCursorPosition,
+      newCursorPosition
+    );
+    editor.selection = newSelection;
+
+    await createCheckbox(editor);
+
+    const dateNow = getDateString(new Date());
+    const content = editor.document.getText();
+    const typeOfBulletPoint = getConfig<string>('typeOfBulletPoint');
+    const expectedResult = `${typeOfBulletPoint} [ ] ${dateNow} this is a text`;
 
     assert.strictEqual(content, expectedResult);
   });

--- a/src/test/spec/defaultSettings.ts
+++ b/src/test/spec/defaultSettings.ts
@@ -15,6 +15,7 @@ export const setSettingsToDefault = async () => {
     dateWhenChecked: true,
     showStatusBarItem: true,
     dateFormat: 'YYYY-MM-DD',
+    dateWhenCreated: false,
   };
   await Promise.all(
     Object.entries(defaultSettings).map(async ([key, value]) => {


### PR DESCRIPTION
* Should fix #17, without an arrow, and without a template for creation date.
* New setting `dateWhenCreated` added, defaults to true, to disable this feature.

Notes:

* Is it needed to have a template for the creation date?
* What's about the dateFormat? It's ignored and always ISO by now.
* Redundant test code should be reorganized maybe.

I would like to remove the creation date if checked at the same day, and use the checked date for creation when reopen without a create date later. What do you think?