### PR TITLE
narrow scope for keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,13 +78,13 @@
         "command": "markdown-checkbox.createCheckbox",
         "key": "ctrl+shift+c",
         "mac": "cmd+shift+c",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && resourceLangId == markdown"
       },
       {
         "command": "markdown-checkbox.markCheckbox",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && resourceLangId == markdown"
       }
     ],
     "menus": {


### PR DESCRIPTION
I could only get `Ctrl + Shift + Enter` working when using this extension with [Markdown Memo](https://github.com/svsool/memo) that has an overlapping keybinding by narrowing the scope slightly and now it's working as expected.
Create checkbox was working fine, but since best practice seems to be using the narrowest scope I also changed this binding to be the same.